### PR TITLE
fix json unmarshal `item.Payload.Forkee` did not work

### DIFF
--- a/newsfeed.go
+++ b/newsfeed.go
@@ -66,7 +66,7 @@ type Payload struct {
 
 // Forkee forkee
 type Forkee struct {
-	ID          string `json:"id"`
+	ID          int32  `json:"id"`
 	Name        string `json:"name"`
 	FullName    string `json:"full_name"`
 	Owner       *Owner `json:"owner"`
@@ -104,7 +104,7 @@ type Member struct {
 
 // Owner owner
 type Owner struct {
-	ID           string `json:"id"`
+	ID           int32  `json:"id"`
 	Login        string `json:"login"`
 	DisplayLogin string `json:"display_login"`
 	GravatarID   string `json:"gravatar_id"`


### PR DESCRIPTION
修复由于 Forkee 和 Owner 结构的 ID 字段数据类型不正确而导致 NewsFeed 的一部分字段无法解析的问题。比如所有的 ForkEvent JSON 的 CreateAt 字段无法正确解析而被置为零值，造成如图所示结果：
![image](https://user-images.githubusercontent.com/11327898/33518592-2255040a-d7d2-11e7-9c72-bf601d1e3902.png)
